### PR TITLE
hide unknown travel destinations

### DIFF
--- a/Retail/core/config.lua
+++ b/Retail/core/config.lua
@@ -162,6 +162,13 @@ config.options = {
                     name = "",
                     order = 25,
                 },
+                remove_unknown = {
+                    type = "toggle",
+                    width = "full",
+                    name = L["config_remove_unknown"],
+                    desc = L["config_remove_unknown_desc"],
+                    order = 25.1,
+                },
                 remove_AreaPois = {
                     type = "toggle",
                     width = "full",

--- a/Retail/core/constants.lua
+++ b/Retail/core/constants.lua
@@ -44,6 +44,7 @@ constants.defaults = {
         show_zeppelin = true,
         show_hzeppelin = true,
         show_note = true,
+        remove_unknown = true,
         remove_AreaPois = true,
         easy_waypoint = true,
         easy_waypoint_dropdown = 1,

--- a/Retail/core/handler.lua
+++ b/Retail/core/handler.lua
@@ -535,6 +535,10 @@ do
             if (private.hidden[currentMapID] and private.hidden[currentMapID][coord]) then
                 return false
             end
+            -- this will check if requirements are fulfilled, when remove_unknown option enabled
+            if (point.requirements and private.db.remove_unknown and not ReqFulfilled(point.requirements)) then
+                return false
+            end
             -- this will check if any node is for specific class
             if (point.class and point.class ~= select(2, UnitClass("player"))) then
                 return false

--- a/Retail/localization/deDE.lua
+++ b/Retail/localization/deDE.lua
@@ -57,6 +57,9 @@ L["config_molemachine_desc"] = "Zeigt die Position von Zielen der Maulwurfmaschi
 L["config_note"] = "Notizen"
 L["config_note_desc"] = "Zeigt zusätzliche Notizen an, wenn diese verfügbar sind."
 
+L["config_remove_unknown"] = "Entferne unbekannte Reiseziele"
+L["config_remove_unknown_desc"] = "Dadurch werden Reiseziele deren Voraussetzung nicht erfüllt werden von der Weltkarte entfernt."
+
 L["config_remove_AreaPois"] = "Entferne Blizzards Knotenpunkte für Reiseziele"
 L["config_remove_AreaPois_desc"] = "Dadurch werden die von Blizzard festgelegten Points of Interest (POIs) für Reiseziele auf der Weltkarte entfernt."
 

--- a/Retail/localization/enUS.lua
+++ b/Retail/localization/enUS.lua
@@ -57,6 +57,9 @@ L["config_molemachine_desc"] = "Show destinations for the Mole Machine."
 L["config_note"] = "Note"
 L["config_note_desc"] = "Show the node's additional notes when it's available."
 
+L["config_remove_unknown"] = "Remove unknown destinations"
+L["config_remove_unknown_desc"] = "This will hide destinations with unfulfilled requirements on the world map."
+
 L["config_remove_AreaPois"] = "Remove Blizzard's POIs for destinations"
 L["config_remove_AreaPois_desc"] = "This will remove the Points of Interest (POIs) set by Blizzard for destinations on the world map."
 


### PR DESCRIPTION
this pr adds an option to hide travel destinations which requirements are not fulfilled, to see only usable stuff

before:
![image](https://user-images.githubusercontent.com/13732585/206451626-924e3607-41df-4ef1-bcbb-3d78831fe8a3.png)

after:
![image](https://user-images.githubusercontent.com/13732585/206451794-f07e5f30-1f99-4f59-aee4-64a4558e05f8.png)

