### PR TITLE
Revealed Portal to Naxxramas

### DIFF
--- a/Retail/data/DB.lua
+++ b/Retail/data/DB.lua
@@ -253,6 +253,8 @@ local TheMasonary = L["The Masonary"]
 local inBRM = L["inside the Blackrock Mountain"]
 local Feralas = GetMapNames(12, 69)
 local DeadwindPass = GetMapNames(13, 42)
+local Naxxramas = GetMapNames(113, 115, 4234)
+local PtoNaxxramas = L["Revealed Portal to Naxxramas"]
 
 ----------------------------------------------------------------------------------------------------
 ----------------------------------------------DATABASE----------------------------------------------
@@ -1248,6 +1250,7 @@ DB.nodes = {
         [38736678] = { icon="boat", label=BtoRatchet, note=NorthernBarrens }
         },
     [13] = { -- Eastern Kingdom
+        [53752981] = { icon="portal", label=PtoNaxxramas, note=Naxxramas, requirements={quest=76263, accquest=true} },
         [44058706] = { icon="zeppelin", multilabel={ZtoOG, PtoUC}, multinote={Durotar, Tirisfal}, faction="Horde" },
         [44058707] = { icon="hzeppelin", label=ZtoOG, note=Durotar, faction="Alliance" },
         [41107209] = { icon="aboat", multilabel={BtoBoreanTundra, BtoBoralus, BtoDI}, multinote={ValianceKeep, TiragardeSound, WakingShores}, faction="Horde" },
@@ -1352,6 +1355,7 @@ DB.nodes = {
         [36577574] = { icon="boat", label=BtoRatchet, note=NorthernBarrens }
         },
     [23] = { -- Eastern Plaguelands
+        [35702309] = { icon="portal", label=PtoNaxxramas, note=Naxxramas, requirements={quest=76263, accquest=true} },
         [75234942] = { icon="orderhall", label=PtoDala, note=BrokenIsles, class="PALADIN" }
         },
     [27] = { -- Dun Morogh

--- a/Retail/localization/deDE.lua
+++ b/Retail/localization/deDE.lua
@@ -324,4 +324,6 @@ L["Portal to the Sepulcher"] = "Portal zum Grabmal"
 L["Waygate to Un'Goro Crater"] = "Tor zum Krater von Un'Goro"
 L["The Masonary"] = "Die Freimaurerei"
 L["inside the Blackrock Mountain"] = "innerhalb des Schwarzfels"
+
+L["Revealed Portal to Naxxramas"] = "Aufgedecktes Portal nach Naxxramas"
 end

--- a/Retail/localization/enUS.lua
+++ b/Retail/localization/enUS.lua
@@ -324,4 +324,6 @@ L["Portal to the Sepulcher"] = true
 L["Waygate to Un'Goro Crater"] = true
 L["The Masonary"] = true
 L["inside the Blackrock Mountain"] = true
+
+L["Revealed Portal to Naxxramas"] = true
 end

--- a/Retail/localization/esES.lua
+++ b/Retail/localization/esES.lua
@@ -210,4 +210,5 @@ L["Zeppelin to Dragon Isle"] = "Zepelín a las Islas Dragón"
 L["Zeppelin to Orgrimmar"] = "Zepelín a Orgrimmar"
 L["Zeppelin to Stranglethorn Vale"] = "Zepelín a Vega de Tuercespina"
 L["Zeppelin to Thunder Bluff"] = "Zepelín a Cima del Trueno"
+L["Revealed Portal to Naxxramas"] = "Portal a Naxxramas revelado"
 end

--- a/Retail/localization/esMX.lua
+++ b/Retail/localization/esMX.lua
@@ -148,4 +148,5 @@ L["Zeppelin to Borean Tundra"] = "Zepelín a Tundra Boreal"
 L["Zeppelin to Orgrimmar"] = "Zepelín a Orgrimmar"
 L["Zeppelin to Stranglethorn Vale"] = "Zepelín a Vega de Tuercespina"
 L["Zeppelin to Thunder Bluff"] = "Zepelín a Cima del Trueno"
+L["Revealed Portal to Naxxramas"] = "Portal a Naxxramas revelado"
 end

--- a/Retail/localization/frFR.lua
+++ b/Retail/localization/frFR.lua
@@ -221,4 +221,5 @@ L["Zeppelin to Orgrimmar"] = "Zeppelin vers Orgrimmar"
 L["Zeppelin to Siren Isle"] = "Zeppelin vers l'Île aux Sirènes"
 L["Zeppelin to Stranglethorn Vale"] = "Zeppelin vers la Vallée de Strangleronce"
 L["Zeppelin to Thunder Bluff"] = "Zeppelin vers les Pitons-du-Tonnerre"
+L["Revealed Portal to Naxxramas"] = "Portail vers Naxxramas révélé"
 end

--- a/Retail/localization/itIT.lua
+++ b/Retail/localization/itIT.lua
@@ -157,4 +157,5 @@ L["Zeppelin to Orgrimmar"] = "Zeppelin per Orgrimmar"
 L["Zeppelin to Siren Isle"] = "Zeppelin per Isola delle Sirene"
 L["Zeppelin to Stranglethorn Vale"] = "Zeppelin per Valle di Rovotorto"
 L["Zeppelin to Thunder Bluff"] = "Zeppelin per Picco del Tuono"
+L["Revealed Portal to Naxxramas"] = "Portale Rivelato per Naxxramas"
 end

--- a/Retail/localization/koKR.lua
+++ b/Retail/localization/koKR.lua
@@ -194,4 +194,5 @@ L["Zeppelin to Dragon Isle"] = "용의 섬으로 가는 비행선"
 L["Zeppelin to Orgrimmar"] = "오그리마로 가는 비행선"
 L["Zeppelin to Stranglethorn Vale"] = "가시덤불 골짜기로 가는 비행선"
 L["Zeppelin to Thunder Bluff"] = "썬더블러프로 가는 비행선"
+L["Revealed Portal to Naxxramas"] = "드러난 낙스라마스로 통하는 차원문"
 end

--- a/Retail/localization/ptBR.lua
+++ b/Retail/localization/ptBR.lua
@@ -189,4 +189,5 @@ L["Zeppelin to Borean Tundra"] = "Zepelim para Tundra Boreana"
 L["Zeppelin to Orgrimmar"] = "Zepelim para Orgrimmar"
 L["Zeppelin to Stranglethorn Vale"] = "Zepelim para Selva do Espinhaço"
 L["Zeppelin to Thunder Bluff"] = "Zepelim para Penhasco do Trovão"
+L["Revealed Portal to Naxxramas"] = "Portal para Naxxramas revelado"
 end

--- a/Retail/localization/ruRU.lua
+++ b/Retail/localization/ruRU.lua
@@ -325,4 +325,6 @@ L["Portal to the Sepulcher"] = "Портал в Гробницу"
 L["Waygate to Un'Goro Crater"] = "Врата к кратеру Ун'Горо"
 L["The Masonary"] = "Каменоломня"
 L["inside the Blackrock Mountain"] = "внутри Черной горы"
+
+L["Revealed Portal to Naxxramas"] = "Открытый портал в Наксрамас"
 end

--- a/Retail/localization/zhCN.lua
+++ b/Retail/localization/zhCN.lua
@@ -326,4 +326,6 @@ L["Portal to the Sepulcher"] = "通往墓地的传送门"
 L["Waygate to Un'Goro Crater"] = "通往安戈洛环形山"
 L["The Masonary"] = "石匠区"
 L["inside the Blackrock Mountain"] = "在黑石山内部"
+
+L["Revealed Portal to Naxxramas"] = "显现出的通往纳克萨玛斯的传送门"
 end

--- a/Retail/localization/zhTW.lua
+++ b/Retail/localization/zhTW.lua
@@ -197,4 +197,5 @@ L["Zeppelin to Dragon Isle"] = "到巨龍群島的飛艇"
 L["Zeppelin to Orgrimmar"] = "到奧格瑪的飛艇"
 L["Zeppelin to Stranglethorn Vale"] = "到荊棘谷的飛艇"
 L["Zeppelin to Thunder Bluff"] = "到雷霆崖的飛艇"
+L["Revealed Portal to Naxxramas"] = "顯現的納克薩瑪斯傳送門"
 end


### PR DESCRIPTION
Can be found in Eastern Plaguelands
Added in patch 10.1.5
https://www.wowhead.com/object=405367

The Dread Citadel - Naxxramas {76263,76264,76265}
Receiving one of the quests due to reputation and completing with the other two quests flagged at the same time.